### PR TITLE
fix: update sky spec when style is changed in maplibre-gl

### DIFF
--- a/.changeset/silver-icons-hope.md
+++ b/.changeset/silver-icons-hope.md
@@ -1,0 +1,5 @@
+---
+"@watergis/maplibre-gl-sky": patch
+---
+
+fix: update sky spec when style is changed in maplibre-gl

--- a/packages/maplibre-gl-sky/src/lib/SkyControl.ts
+++ b/packages/maplibre-gl-sky/src/lib/SkyControl.ts
@@ -14,6 +14,8 @@ export class SkyControl {
 
 	private options: Options = defaultSkyOptions;
 
+	private addToOptions?: AddToOptions
+
 	/**
 	 * Constructor
 	 * @param options Options object
@@ -41,26 +43,33 @@ export class SkyControl {
 	 */
 	public addTo(map: Map, options?: AddToOptions) {
 		this.map = map;
+		this.addToOptions = options;
 		this.map.setMaxPitch(this.options.maxPitch);
 
-		const currentSky = this.getSky(options);
-		if (!currentSky) return;
-
 		if (this.map.isStyleLoaded()) {
-			this.map.setSky(currentSky);
+			this.updateSky()
 		} else {
 			this.map.once('load', () => {
-				this.map?.setSky(currentSky);
+				this.updateSky()
 			});
 		}
 
 		if (!options?.location) {
 			this.map.on('moveend', () => {
-				const currentSky = this.getSky(options);
-				if (!currentSky) return;
-				this.map?.setSky(currentSky);
+				this.updateSky()
 			});
 		}
+
+		// register updateSky event on styledata, so sky can be updated when style is changed.
+		this.map.off('styledata', this.updateSky.bind(this))
+		this.map.on('styledata', this.updateSky.bind(this))
+	}
+
+	private updateSky() {
+		if (!this.map) return
+		const currentSky = this.getSky(this.addToOptions);
+		if (!currentSky) return
+		this.map?.setSky(currentSky);
 	}
 
 	/**

--- a/packages/maplibre-gl-sky/src/lib/SkyControl.ts
+++ b/packages/maplibre-gl-sky/src/lib/SkyControl.ts
@@ -14,7 +14,7 @@ export class SkyControl {
 
 	private options: Options = defaultSkyOptions;
 
-	private addToOptions?: AddToOptions
+	private addToOptions?: AddToOptions;
 
 	/**
 	 * Constructor
@@ -47,28 +47,28 @@ export class SkyControl {
 		this.map.setMaxPitch(this.options.maxPitch);
 
 		if (this.map.isStyleLoaded()) {
-			this.updateSky()
+			this.updateSky();
 		} else {
 			this.map.once('load', () => {
-				this.updateSky()
+				this.updateSky();
 			});
 		}
 
 		if (!options?.location) {
 			this.map.on('moveend', () => {
-				this.updateSky()
+				this.updateSky();
 			});
 		}
 
 		// register updateSky event on styledata, so sky can be updated when style is changed.
-		this.map.off('styledata', this.updateSky.bind(this))
-		this.map.on('styledata', this.updateSky.bind(this))
+		this.map.off('styledata', this.updateSky.bind(this));
+		this.map.on('styledata', this.updateSky.bind(this));
 	}
 
 	private updateSky() {
-		if (!this.map) return
+		if (!this.map) return;
 		const currentSky = this.getSky(this.addToOptions);
-		if (!currentSky) return
+		if (!currentSky) return;
 		this.map?.setSky(currentSky);
 	}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@floating-ui/dom':
         specifier: 1.6.10
         version: 1.6.10
+      '@watergis/maplibre-gl-sky':
+        specifier: workspace:^
+        version: link:../../packages/maplibre-gl-sky
       highlight.js:
         specifier: 11.10.0
         version: 11.10.0
@@ -97,9 +100,6 @@ importers:
       '@watergis/maplibre-center-icon':
         specifier: ^3.0.1
         version: 3.0.1(svelte@4.2.19)
-      '@watergis/maplibre-gl-sky':
-        specifier: workspace:^
-        version: link:../../packages/maplibre-gl-sky
       autoprefixer:
         specifier: 10.4.20
         version: 10.4.20(postcss@8.4.41)

--- a/sites/demo/package.json
+++ b/sites/demo/package.json
@@ -22,7 +22,6 @@
 		"@types/eslint": "^9.6.0",
 		"@types/node": "22.5.0",
 		"@watergis/maplibre-center-icon": "^3.0.1",
-		"@watergis/maplibre-gl-sky": "workspace:^",
 		"autoprefixer": "10.4.20",
 		"eslint": "^9.9.1",
 		"eslint-config-prettier": "^9.1.0",
@@ -45,6 +44,7 @@
 	"type": "module",
 	"dependencies": {
 		"@floating-ui/dom": "1.6.10",
+		"@watergis/maplibre-gl-sky": "workspace:^",
 		"highlight.js": "11.10.0"
 	}
 }

--- a/sites/demo/src/routes/(demo)/maplibre/+page.svelte
+++ b/sites/demo/src/routes/(demo)/maplibre/+page.svelte
@@ -43,7 +43,7 @@
 	let bestTime: TimeType;
 	let currentDate: Date;
 
-	let sky: SkyControl
+	let sky: SkyControl;
 
 	onMount(() => {
 		map = new Map({

--- a/sites/demo/src/routes/(demo)/maplibre/+page.svelte
+++ b/sites/demo/src/routes/(demo)/maplibre/+page.svelte
@@ -43,6 +43,8 @@
 	let bestTime: TimeType;
 	let currentDate: Date;
 
+	let sky: SkyControl
+
 	onMount(() => {
 		map = new Map({
 			container: 'map',
@@ -77,7 +79,9 @@
 
 	const updateSuncalcTimes = () => {
 		const center = map.getCenter();
-		const sky = new SkyControl(defaultOptions);
+		if (!sky) {
+			sky = new SkyControl(defaultOptions);
+		}
 		currentDate = new Date();
 		suncalcTimes = sky.getTimesByLocation(center.lng, center.lat, currentDate);
 		bestTime = sky.getBestTimeNameByLocation(center.lng, center.lat, currentDate);
@@ -85,7 +89,9 @@
 
 	const initSky = (type?: TimeType) => {
 		if (!map) return;
-		const sky = new SkyControl(defaultOptions);
+		if (!sky) {
+			sky = new SkyControl(defaultOptions);
+		}
 
 		let options: AddToOptions = {};
 		if (type) {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

maplibre-gl-js reset sky spec when style is changed. Listening styledata event to update sky spec automatically.

## Plugin

Select a plugin related to this PR.

- [x] maplibre-gl-sky

## Type of Pull Request
<!-- ignore-task-list-start -->
- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] Make sure all the exsiting features working well
- [x] Make sure a changeset file is added if your PR changes package code
<!-- ignore-task-list-end -->
